### PR TITLE
SSID取得に利用していたairportコマンドが利用できなくなったため、別の手段で取得する

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/polidog/slack-wifi-status
+
+go 1.21.10
+
+require (
+	github.com/BurntSushi/toml v1.4.0
+	github.com/go-errors/errors v1.5.1
+	github.com/jessevdk/go-flags v1.6.1
+)
+
+require golang.org/x/sys v0.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
+github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/go-errors/errors v1.5.1 h1:ZwEMSLRCapFLflTpT7NKaAc7ukJ8ZPEjzlxt8rPN8bk=
+github.com/go-errors/errors v1.5.1/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
+github.com/jessevdk/go-flags v1.6.1 h1:Cvu5U8UGrLay1rZfv/zP7iLpSHGUZ/Ou68T0iX1bBK4=
+github.com/jessevdk/go-flags v1.6.1/go.mod h1:Mk8T1hIAWpOiJiHa9rJASDK2UGWji0EuPGBnNLMooyc=
+golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
+golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=


### PR DESCRIPTION
macOS Sonoma以降の環境ではSSID取得に使用していたライブラリが機能しなくなったためnetworksetupコマンドで取得するロジックを追加しました。

参考URL
https://zenn.dev/takafuu/articles/6876067e30eadc